### PR TITLE
Normalize DataDep handling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,3 +7,9 @@ BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"
 DataDeps = "124859b0-ceae-595e-8997-d05f6a7a8dfe"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 environment:
+  DATADEPS_ALWAYS_ACCEPT: True
   matrix:
   - julia_version: 1.0
   - julia_version: 1.1

--- a/src/GenderInference.jl
+++ b/src/GenderInference.jl
@@ -17,8 +17,11 @@ include("data_registrations.jl")
 include("data_management.jl")
 include("inference.jl")
 
-# function __init__()
-#     include("data_registrations.jl")
-# end
+function __init__()
+    init_us_census()
+
+    # Define global constant
+    @eval const NAMES = parsedataset(datadep"US Census - names", RawDataSet("USCensus"))
+end
 
 end # module Gender Inference

--- a/src/data_management.jl
+++ b/src/data_management.jl
@@ -61,7 +61,3 @@ function parsedataset(datfolder, ::RawDataSet{:USCensus})
     end
     return nds
 end
-
-
-
-const NAMES = parsedataset(datadep"US Census - names", RawDataSet("USCensus"))

--- a/src/data_registrations.jl
+++ b/src/data_registrations.jl
@@ -1,7 +1,11 @@
-register(DataDep(
-    "US Census - names",
-    """US Census data, 1880-2017.
-        https://catalog.data.gov/dataset/baby-names-from-social-security-card-applications-national-level-data""",
-    "https://www.ssa.gov/oact/babynames/names.zip",
-    post_fetch_method=file->run(`unzip $file`)
-    ))
+
+# This will be called by __init__
+function init_us_census()
+    register(DataDep(
+        "US Census - names",
+        """US Census data, 1880-2017.
+            https://catalog.data.gov/dataset/baby-names-from-social-security-card-applications-national-level-data""",
+        "https://www.ssa.gov/oact/babynames/names.zip",
+        post_fetch_method=unpack
+        ))
+end


### PR DESCRIPTION
A few things:

 - The reason you were getting `KeyError`, when the datadep was registered in `init` was that you were accessing the datadep at global scope to define the `NAMES` constant. That happens befoire `__init__` is run. But using init is still preferable as otherwise weird things can happen due to precompilation.
 - rather than calling `include` from `__init__` I defined a `init_us_census` function and called that from `__init__` as `include` works weirdly when called from within functions.
 - I fixed up the AppVeyor config and make `Pkg.test` work without warnings.
 - Rather than shalling out to use `unzip` I switched it to use DataDeps's own `unpack` function, which is a bit more general and cross platform.